### PR TITLE
Add stopping criterion as an option

### DIFF
--- a/example_polynomial.m
+++ b/example_polynomial.m
@@ -1,38 +1,37 @@
 % An example for the specialised polynomial algorithm
-clear all;
+rng(1)
 
-rng(5)
+% m is the size of the matrix polynomial
 m = 8;
+% k is the degree of the matrix polynomial
 k = 2;
+% d is the largest allowed minimal index
+d = floor((k*(m-1))/2);
+
 A0 = randn(m) + 1i*randn(m);
 A1 = randn(m) + 1i*randn(m);
 A2 = randn(m) + 1i*randn(m);
 
-n = length(A1);
-
-d = floor((k*(n-1))/2);
-
-V0 = randn(n,d+1);
+% Initial guess for the vector in the kernel
+V0 = randn(m,d+1);
 V0 = V0./norm(V0,'f');
 
-A = [A0 A1 A2];
-
+% Parameters and options used by the algorithm
 options = struct();
-options.maxiter = 500;
-% options.maxtime = 4;
+options.maxiter = 50;
 options.tolgradnorm = 1e-6;
-% options.debug=0;
 options.solver = @trustregions;
 options.verbosity = 1;
-% options.epsilon_decrease = 'f';
-options.max_outer_iterations = 30;
-options.y = 0;
-
+options.epsilon_decrease = 'f';
+options.max_outer_iterations = 800;
+options.stopping_criterion = 1e-14;
 
 use_hessian = true;
 
 
 % Right kernel:
+A = [A0 A1 A2];
+
 problem = nearest_singular_polynomial(A, d, use_hessian);
           
 [V_right,~,info_right, results_right] = penalty_method(problem, V0, options);

--- a/penalty_method.m
+++ b/penalty_method.m
@@ -15,6 +15,11 @@ function [x, cost, info, results] = penalty_method(problem, x0, options)
 % a numerical constant (default=0.5), 'f' for an adaptive decrease based on 
 % the function value, 'g' for a decrease based on the value of the gradient.
 %
+% options.stopping_criterion specifies the value that the absolute 
+% error in the constraint needs to reach before the iteration is stopped.
+% If no value is provided, then a relative error of 1e-16 is used as the
+% stopping cirerion.
+%
 % Note for those implementing new problem structures:
 % This function accesses store.normAv and store.condM, which must exist.
 
@@ -22,6 +27,7 @@ function [x, cost, info, results] = penalty_method(problem, x0, options)
     default.epsilon_decrease = 0.5;
     default.max_outer_iterations = 40;
     default.y = [];
+    default.stopping_criterion = [];
 
     if not(exist('options', 'var'))
         options = struct();
@@ -70,9 +76,15 @@ function [x, cost, info, results] = penalty_method(problem, x0, options)
             results.augmented_lagrangian(k) = cost - epsilon*norm(y)^2;
         end
 
+        if isempty(options.stopping_criterion)
+            constraint_satisfied = relative_constraint_error < 1e-16;
+        else
+            constraint_satisfied = norm(cons) < options.stopping_criterion;
+        end
+
         % we want to break out here so that we can return the y truly used
-        % before updates
-        if relative_constraint_error < 1e-16 || k == options.max_outer_iterations
+        % before updates    
+        if constraint_satisfied || k == options.max_outer_iterations
             break
         end
 


### PR DESCRIPTION
The user can now specify the stopping criterion. This fixes the issue with the stopping criterion for the penalty method. This is also needed for easier reproduction of the numerical experiments for matrix polynomials.

Closes #3